### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary
- set dependabot to manage npm packages

## Testing
- `npm run lint` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844676fa7a8832398e8bff09af33b62