### PR TITLE
Fix blog article transform class

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -59,7 +59,7 @@ function Blog() {
           {blogPosts.map((post) => (
             <article 
               key={post.id}
-              className="bg-pink-50 rounded-lg p-6 transition-transform duration-300 hover:transform hover:scale-[1.02] border-2 border-purple-200"
+              className="bg-pink-50 rounded-lg p-6 transition-transform duration-300 transform hover:scale-[1.02] border-2 border-purple-200"
             >
               <div className="flex items-start gap-4">
                 <div className="flex-shrink-0 bg-white p-3 rounded-full shadow-md">


### PR DESCRIPTION
## Summary
- update class for article components to use `transform` instead of `hover:transform`

## Testing
- `npm run lint` *(fails: cannot pass lint errors in other files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68447c125e648323b8592e79ba5009c3